### PR TITLE
Support utf8 encoding in team note

### DIFF
--- a/Engines/python/extracted_from_exports.py
+++ b/Engines/python/extracted_from_exports.py
@@ -20,9 +20,9 @@ def note_txt_append(team_name, export_destination_path):
         
         with open(teamnotes_name, "a") as f2:
             f2.write(f". \n- \n-- {team_name}'s note file: \n- \n")
-        with open(note_path, "r") as f:
+        with open(note_path, "r", encoding="utf8") as f:
             teamnotes = f.read()
-            with open(teamnotes_name, "a") as f2:
+            with open(teamnotes_name, "a", encoding="utf8") as f2:
                 f2.write(f"{teamnotes}\n")
 
 

--- a/Engines/python/lib/bins_update.py
+++ b/Engines/python/lib/bins_update.py
@@ -203,7 +203,7 @@ def bins_update():
     for file_name in [f for f in os.listdir(extracted_exports_dir) if f.endswith(".txt")]:
       
         file_path = os.path.join(extracted_exports_dir, file_name)
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding="utf8") as file:
 
             # Initialize variables
             stop = None

--- a/Engines/python/lib/txt_kits_count.py
+++ b/Engines/python/lib/txt_kits_count.py
@@ -4,7 +4,7 @@ from .bins_update import bytes_from_color_entry
 
 def txt_kits_count(file_path):
   
-    with open(file_path, 'r') as file:
+    with open(file_path, 'r', encoding="utf8") as file:
 
         # Initialize variables
         stop = None


### PR DESCRIPTION
On windows, the default encoding is set to cp1252, which will make the compiler crash if you write some much needed other notes like the following:
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣠⣤⣤⣤⣤⡤⠶⠷⠖⣶⠶⣶⣶⣤⣤⣤⣤⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⠟⠋⠉⠻⢿⣹⣿⣿⠄⠀⠰⣴⣷⣿⣿⣿⣿⠉⢿⣟⠹⠿⢶⣄⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡾⠿⢿⣄⠀⠀⠈⠙⠋⠁⠀⠘⣿⣯⡻⢿⣿⡿⣿⣦⣿⢿⠄⣁⠘⣿⡄⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⡿⣷⣶⣿⣿⣷⢶⣦⡀⠀⠀⠐⣾⢿⣿⣧⣠⣿⣾⣽⡅⠀⠀⡄⠣⠀⣻⣧⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⠟⢡⣿⡯⠋⠈⠉⠉⠉⠁⠀⠀⠀⣼⣿⣿⣽⣿⣯⡿⣾⡇⣀⠝⠀⠀⢰⣼⣿⡄⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⡖⠀⠉⠴⢿⡅⣴⣆⠀⠀⠀⠀⣸⣿⣿⣿⠟⣡⢋⣑⣾⣿⠋⠀⢀⠄⢠⡏⣿⡇⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢠⣯⣥⣗⣠⣐⣢⣾⣻⣿⣷⣶⣒⣠⣶⣻⡿⢻⠟⣼⠛⠏⠃⠘⠉⢃⡆⠨⠀⠀⢱⣽⣷⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣵⣥⣀⣐⣤⣅⡜⢁⠑⠀⠀⠺⢿⣿⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠙⠛⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠿⠛⠂⠁⡆⢠⣀⠂⠀⣈⣿⡇⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⠃⣰⣷⣼⣧⣤⣆⢹⣾⡠⠗⣀⢿⣿⡇⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⣿⣿⣿⣿⡟⣿⡿⢻⣿⣿⢽⣿⣿⣟⣅⠀⠀⠈⣿⣷⣿⣿⣿⠀⣿⠁⠀⣻⠈⣿⣿⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⢠⣿⣿⣿⣿⣿⣶⣿⣧⣶⣿⠶⣈⣿⣿⣿⣿⠓⠀⡐⣿⣿⣿⣿⣿⡾⣿⢃⠸⣻⡀⣽⣿⡀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⣾⣿⣿⣿⣿⣿⣯⣿⣿⣻⣿⣿⣿⣿⣿⣿⣿⣧⣾⣿⣿⣿⡽⣟⣃⣴⣿⣿⣼⣾⣿⣻⣿⣇⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣼⣯⣿⣿⣿⣯⣿⣿⣿⢣⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣿⣿⣿⣿⣦⣍⢻⣿⡇⢻⣿⠀⠀⠀
⠀⠀⠀⠀⠀⠀⢰⣿⡿⢏⣡⣾⣿⣿⣿⣿⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡛⢁⣾⡝⢀⡻⣿⡇⠀⠀
⠀⠀⠀⠀⠀⣠⣿⣿⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⣋⣿⡿⢿⣿⣷⣎⢸⡏⡌⣻⠸⣿⠀⠀
⠀⠀⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣽⣷⣿⣿⣾⢳⣤⣹⣿⣾⡿⠀⠃⠟⣿⡆⠀
⠀⣠⣾⣿⠿⠿⠿⠻⠿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠋⢚⣙⣯⣿⡇⢘⡟⣇⣀⢽⣿⣠⡀⢸⣾⣇⠀
⣼⣿⣭⣧⣄⣀⣀⡀⠀⠀⠀⠈⣙⠭⣙⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⡿⡗⢿⣿⡿⠭⢧⢈⣴⢿⡟⠉⠂⠈⠋⣿⡀
⣿⣿⣿⣿⣿⣿⣿⣿⣾⣶⣤⣜⣋⣄⣋⣝⣟⣿⣹⢿⣿⣿⡿⣿⣿⣿⣿⣿⣿⣧⣶⣿⡆⡀⢰⣿⠃⣔⠇⠀⠀⢀⢟⣿⡇
⠈⠉⠙⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⣿⣿⣹⡿⣿⣿⠿⠐⣁⣀⢺⢄⡀⠀⣀⣯⡌⢻⣧
⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⣡⣶⣾⣿⣿⣿⣿⡟⣋⣹⣿⠚⠀⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣾⣿
⠀⠀⢠⣿⣿⣿⣿⣿⣿⣿⠿⡿⠿⡿⠿⠟⠛⠉⢀⣴⣿⣿⣿⣿⣿⣿⡟⡺⡿⢛⡄⠀⡀⠼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⠀⢀⣾⣛⣉⣉⣀⣀⣀⡀⣀⢀⠀⠀⠀⢠⠠⠀⢸⡿⣿⣿⣿⣿⣿⣿⣱⡿⢂⡾⠁⠀⠀⠀⠀⠈⠻⣿⣿⣿⣿⣿⣿⣿⣿
⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣽⣷⣧⣿⣥⣾⣿⣇⢹⢻⣽⡿⣰⣜⠁⠀⠀⠀⠀⠀⠀⠀⠘⣿⣿⣿⡿⣯⣿⣿
⠀⠀⠸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠁⠀⠰⢀⣨⠽⢿⡿⠛⠁⠚⠀⣠⠘⠃⠀⠀⠀⠀⠀⠀⢭⣫⠞⠧⡘⣽⣿
⠀⠀⠀⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠄⠀⠀⠀⠙⢚⡿⠠⠀⡤⠀⣠⣿⠇⣀⡀⠀⠀⠀⠀⠀⠊⠈⠀⠀⠌⢺⣿
⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠉⠀⠀⠀⠀⠀⣀⣪⣽⣃⡾⣶⣼⣿⣷⢰⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⢰⢩⣾⣿
⠀⠀⠀⢸⣿⡿⠙⠿⢿⠟⠻⠿⠿⠏⠀⠀⠠⠂⢀⠀⣼⡿⣃⢿⣛⡛⣥⣿⣻⣿⡟⠉⠀⠀⠀⠀⠀⠀⢐⣵⣤⣄⣿⣿⣿
⠀⠀⠀⠘⣿⡆⠀⠀⠀⠀⠀⠀⠀⠀⢀⠈⠇⠼⢁⣠⠏⠁⡀⣸⠋⢵⢾⣿⡝⠟⠀⠀⠀⠀⠀⣀⣤⣿⣿⣿⣿⣿⣿⣿⡏
⠀⠀⠀⠀⢻⣿⣷⣦⣦⣤⣠⣀⣀⣀⢦⠀⢀⣚⢉⠀⢠⡾⡻⠙⠱⠚⠫⣏⣡⣤⣶⣾⣿⣿⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃
⠀⠀⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠁⠀
⠀⠀⠀⠀⠀⠀⠀⠈⠙⠻⠿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⠋⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠉⠉⠙⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠋⠉⠁⠀⠀⠀⠀⠀⠀